### PR TITLE
notes: Fix README.md typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Should you chose to use the kernel as a base for your own, either fork the kerne
 
 ```bash
 git fetch <android-linux-stable_repo_url> <branch_to_use>
-git branch -b <your_branch_name> FETCH_HEAD
+git checkout -b <your_branch_name> FETCH_HEAD
 git push --set-upstream origin <your_branch_name>
 ```
 


### PR DESCRIPTION
The operator "-b" does not exist in "git branch". However, it does exist on "git checkout" and it gives the expected result (a new branch with a the repository fetch). Should work fine like this.